### PR TITLE
Patch apache-airflow security advisories (bump to 2.11.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,8 @@ dev = [
     "memory-profiler>=0.60.0",
     "psutil>=5.9.0",
     "scipy>=1.9.0",
-    "apache-airflow>=2.7.0",
-    "apache-airflow-providers-docker>=3.5.0",
+    "apache-airflow>=2.11.1,<3.0.0",
+    "apache-airflow-providers-docker>=3.9.0,<4.0.0",
 ]
 docs = [
     "sphinx>=4.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -101,8 +101,8 @@ setuptools>=65.0.0,<75.0.0
 twine>=4.0.0,<5.2.0
 
 # Orchestration
-apache-airflow>=3.2.2,<3.3.0
-apache-airflow-providers-docker>=4.5.0,<4.6.0
+apache-airflow>=2.11.1,<3.0.0
+apache-airflow-providers-docker>=3.9.0,<4.0.0
 
 # API Development & Testing
 httpx>=0.23.0,<0.28.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -101,8 +101,8 @@ setuptools>=65.0.0,<75.0.0
 twine>=4.0.0,<5.2.0
 
 # Orchestration
-apache-airflow>=2.7.0,<2.10.0
-apache-airflow-providers-docker>=3.5.0,<3.14.0
+apache-airflow>=3.2.2,<3.3.0
+apache-airflow-providers-docker>=4.5.0,<4.6.0
 
 # API Development & Testing
 httpx>=0.23.0,<0.28.0


### PR DESCRIPTION
Addresses the Dependabot `apache-airflow` advisories. Bumps to the latest **2.x** release, `2.11.1`, in both `requirements-dev.txt` and `pyproject.toml`.

## What this fixes
| CVE | Issue | Affects 2.x? | Patched |
|-----|-------|:---:|---------|
| CVE-2024-56373 | LogTemplate code injection (web-server) | ✅ yes | **2.11.1** ✔ |
| CVE-2025-68675 | Proxy credentials leak in task logs | ✅ yes | **2.11.1** ✔ |

## Why not upgrade to 3.x
The other two alerts are only "patched" in the 3.x line, but neither actually affects a 2.x deployment:

- **CVE-2025-54550** (example_xcom RCE) — per the advisory, *"does not affect Airflow release; example_dags are not supposed to be enabled in production."* It's an unsafe **example/doc pattern**, and this project runs with `AIRFLOW__CORE__LOAD_EXAMPLES=False`.
- **CVE-2026-45360** (deserialization via `DeadlineReference`) — the vulnerable Deadline feature is **Airflow 3.x-only**; the code path does not exist in 2.x.

Going to 3.x would be a major migration (Dockerfile base image → Python ≥3.10, `webserver`→`api-server`, `db init`→`db migrate`, DAG import paths, `schedule_interval`/`provide_context` removals) that couldn't be validated here — and would *introduce* the feature the deserialization CVE lives in. Staying on the patched 2.x line is the lower-risk fix.

## Changes
- `apache-airflow`: `>=2.7.0,<2.10.0` → `>=2.11.1,<3.0.0`
- `apache-airflow-providers-docker`: `>=3.5.0,<3.14.0` → `>=3.9.0,<4.0.0` (2.x-compatible)
- Same floors applied in `pyproject.toml`

No DAG, Dockerfile, or compose changes required. `dags/ahgd_pipeline.py` remains 2.x-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)