### PR TITLE
Security: bump patchable Python deps (incl. 1 critical)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -48,7 +48,7 @@ sphinxcontrib-mermaid>=0.7.0,<0.10.0
 ipython>=8.0.0,<8.29.0
 jupyter>=1.0.0,<1.1.0
 notebook>=6.5.0,<7.3.0
-jupyterlab>=3.5.0,<4.3.0
+jupyterlab>=4.5.7,<5.0.0
 ipykernel>=6.15.0,<6.30.0
 jupyter-server>=1.18.0,<2.15.0
 jupyter-core>=4.11.0,<5.8.0
@@ -97,7 +97,7 @@ coveralls>=3.3.0,<4.1.0
 # Build Tools
 build>=0.8.0,<1.3.0
 wheel>=0.37.0,<0.45.0
-setuptools>=65.0.0,<75.0.0
+setuptools>=78.1.1,<82.0.0
 twine>=4.0.0,<5.2.0
 
 # Orchestration
@@ -115,7 +115,7 @@ starlette>=0.26.0,<0.39.0
 # selenium>=4.10.0,<4.26.0
 
 # Security Fix: CVE-2025-47287 - Tornado DoS vulnerability
-tornado>=6.2.0,<6.5.0
+tornado>=6.5.7,<7.0.0
 
 # Additional Development Security Fixes
 # Note: See requirements.txt for additional security fixes applied

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ semver>=3.0.0,<3.1.0
 
 # Web & HTTP
 requests>=2.25.0,<2.33.0
-urllib3>=1.26.0,<2.3.0
+urllib3>=2.7.0,<3.0.0
 httpx>=0.23.0,<0.28.0
 
 # File Format Support
@@ -55,11 +55,11 @@ transformers>=4.30.0,<4.45.0
 
 # Additional Security Fixes
 protobuf>=3.20.0,<5.28.0
-setuptools>=65.0.0,<75.0.0
-lightgbm>=3.3.0,<4.6.0
+setuptools>=78.1.1,<82.0.0
+lightgbm>=4.6.0,<5.0.0
 pillow>=9.5.0,<11.0.0
 pygments>=2.15.0,<2.19.0
-rfc3161-client>=0.0.1,<0.1.0
+rfc3161-client>=1.0.6,<2.0.0
 
 # Configuration & Environment
 python-dotenv>=0.19.0,<1.1.0
@@ -97,7 +97,7 @@ joblib>=1.1.0,<1.5.0
 cloudpickle>=2.0.0,<3.1.0
 
 # Network & API
-aiohttp>=3.8.0,<3.11.0
+aiohttp>=3.14.1,<4.0.0
 aiofiles>=0.8.0,<24.2.0
 fastapi>=0.95.0,<0.115.0
 uvicorn>=0.20.0,<0.32.0


### PR DESCRIPTION
Raises version pins to clear Dependabot advisories where a **non-breaking stable** patched release exists.

| Package | From | To | Severity |
|---|---|---|---|
| rfc3161-client | <0.1.0 | >=1.0.6 | **CRITICAL** |
| aiohttp | <3.11.0 | >=3.14.1 | low |
| urllib3 | <2.3.0 | >=2.7.0 | moderate |
| setuptools | <75.0.0 | >=78.1.1 | high |
| tornado | <6.5.0 | >=6.5.7 | high |
| jupyterlab | <4.3.0 | >=4.5.7 | low |
| lightgbm | <4.6.0 | >=4.6.0 | high |

**Deliberately excluded** (breaking major/prerelease bumps that need a manual migration + test pass): `transformers`→5.x, `starlette`→1.x, `black`→26, `pytest`→9, plus several transitive-only advisories with no direct pin. `apache-airflow` is handled separately in #6.

No lockfile in this repo, so these can't be resolution-tested from CI here — please let CI run before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)